### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie-token-tester)
 
+## [0.0.2](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.0.2) - 2021-01-12
+### Fixed
+- Improved handling of string types for `success` and `revert` kwargs in `ERC20` init
+- Explicitly target Vyper version `0.2.8` to avoid issues when Solidity is not installed
+
 ## [0.0.1](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.0.1) - 2020-12-12
 - Initial alpha release

--- a/brownie_tokens/template.py
+++ b/brownie_tokens/template.py
@@ -78,7 +78,7 @@ def ERC20(
         return_statement=RETURN_STATEMENT[success],
         fail_statement=FAIL_STATEMENT[fail],
     )
-    deployer = compile_source(source).Vyper
+    deployer = compile_source(source, vyper_version="0.2.8").Vyper
 
     return deployer.deploy(
         name,

--- a/brownie_tokens/template.py
+++ b/brownie_tokens/template.py
@@ -21,6 +21,12 @@ FAIL_STATEMENT = {
     None: "return",
 }
 
+STRING_CONVERT = {
+    "true": True,
+    "false": False,
+    "none": None,
+}
+
 with Path(__file__).parent.joinpath("token-template.vy").open() as fp:
     TEMPLATE = fp.read()
 
@@ -29,7 +35,7 @@ def ERC20(
     name: str = "Test Token",
     symbol: str = "TST",
     decimals: int = 18,
-    success: Union[bool, None] = True,
+    success: Union[bool, str, None] = True,
     fail: Union[bool, str, None] = "revert",
 ) -> Contract:
     """
@@ -54,6 +60,12 @@ def ERC20(
     Contract
         Deployed ERC20 contract
     """
+    # understand success and fail when given as strings
+    if isinstance(success, str) and success.lower() in STRING_CONVERT:
+        success = STRING_CONVERT[success.lower()]
+    if isinstance(fail, str) and fail.lower() in STRING_CONVERT:
+        fail = STRING_CONVERT[fail.lower()]
+
     if success not in RETURN_STATEMENT:
         valid_keys = [str(i) for i in RETURN_STATEMENT.keys()]
         raise ValueError(f"Invalid value for `success`, valid options are: {', '.join(valid_keys)}")

--- a/brownie_tokens/token-template.vy
+++ b/brownie_tokens/token-template.vy
@@ -1,4 +1,4 @@
-# @version ^0.2.0
+# @version 0.2.8
 """
 @notice Mock non-standard ERC20 for testing
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 
 [bumpversion:file:setup.py]
 
 [flake8]
 max-line-length = 100
 ignore = E203,W503
-per-file-ignores =
+per-file-ignores = 
 	*/__init__.py: F401
 
 [tool:isort]
@@ -24,7 +24,7 @@ ignore_missing_imports = True
 follow_imports = silent
 
 [tool:pytest]
-addopts =
+addopts = 
 	--cov brownie_tokens/
 	--cov-report term
 	--cov-report xml

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="brownie-token-tester",
     packages=find_packages(exclude=["tests", "tests.*"]),
     py_modules=["brownie_tokens"],
-    version="0.0.1",  # don't change this manually, use bumpversion instead
+    version="0.0.2",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="Helper objects for generating ERC20s while testing a Brownie project.",
     long_description=long_description,


### PR DESCRIPTION
### What I did
- Improved handling of string types for `success` and `revert` kwargs in `ERC20` init
- Explicitly target Vyper version `0.2.8` to avoid issues when Solidity is not installed