### PR TITLE
Custom minting: extend supported tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie-token-tester)
+- Add custom minting logic for tokens: pBTC, wZEC, renZEC, renBTC, wBTC, sBTC, tBTC, aave tokens
+- `forked.py`: Add handling of custom minting logic if token name starts with a specified prefix (e.g. 'AAVE') and custom minting logic for address does not exist
 
 ## [0.0.3](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.0.3) - 2021-01-13
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Helper objects for generating ERC20s while testing a Brownie project.
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
-* [brownie](https://github.com/eth-brownie/brownie) version [1.11.6](https://github.com/eth-brownie/brownie/releases/tag/v1.11.6) or greater
-* [ganache-cli](https://github.com/trufflesuite/ganache-cli) version [6.11.0](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.11.0) or greater
+- [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
+- [brownie](https://github.com/eth-brownie/brownie) version [1.11.6](https://github.com/eth-brownie/brownie/releases/tag/v1.11.6) or greater
+- [ganache-cli](https://github.com/trufflesuite/ganache-cli) version [6.11.0](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.11.0) or greater
 
 ## Installation
 
@@ -60,8 +60,8 @@ def ERC20(
 ) -> Contract:
 ```
 
-* The `success` kwarg is used to set the token's return value upon a successful call to `approve`, `transfer` or `transferFrom`. Valid values are `True`, `False`, and `None`.
-* The `fail` kwarg sets the token's behaviour upon failed calls to the above methods. Use `"revert"` if the transaction should revert, or `True`, `False`, and `None` to return a value without reverting.
+- The `success` kwarg is used to set the token's return value upon a successful call to `approve`, `transfer` or `transferFrom`. Valid values are `True`, `False`, and `None`.
+- The `fail` kwarg sets the token's behaviour upon failed calls to the above methods. Use `"revert"` if the transaction should revert, or `True`, `False`, and `None` to return a value without reverting.
 
 The resulting deployment adheres to the [ERC20 Token Standard](https://eips.ethereum.org/EIPS/eip-20) and additionally implements one non-standard method:
 
@@ -76,6 +76,18 @@ This method increases the balance of `target` by `amount`. It may be called by a
 `MintableForkToken` is used to standardize the process of minting tokens when working in a [forked mainnet](https://eth-brownie.readthedocs.io/en/stable/network-management.html#using-a-forked-development-network) environment. The `MintableForkToken` class inherits from and may be used interchangeably with the [`Contract`](https://eth-brownie.readthedocs.io/en/stable/api-network.html#contract-and-projectcontract) class. It exposes one additional method, `_mint_for_testing`, with the same API as given above.
 
 For tokens where [custom logic is implemented](https://github.com/iamdefinitelyahuman/brownie-token-tester/blob/master/brownie_tokens/forked.py#L52), this is an actual minting event. For most tokens, the "minting" process involves a query to the [Ethplorer API](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#get-top-token-holders) to get a list of top token holders, and then transferring their balances to `target`.
+
+Tokens for which `brownie-testing-tokens` currently implements custom minting logic are:
+
+- [x] Aave tokens
+- [x] LinkUSD
+- [x] pBTC
+- [x] renBTC
+- [x] renZEC
+- [x] RSV
+- [x] USDN
+- [x] wBTC
+- [x] wZEC
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Tokens for which custom logic is currently implemented:
 - [x] renZEC
 - [x] RSV
 - [x] USDN
+- [x] sBTC
+- [x] tBTC
 - [x] wBTC
 - [x] wZEC
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This method increases the balance of `target` by `amount`. It may be called by a
 
 For tokens where [custom logic is implemented](https://github.com/iamdefinitelyahuman/brownie-token-tester/blob/master/brownie_tokens/forked.py#L52), this is an actual minting event. For most tokens, the "minting" process involves a query to the [Ethplorer API](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#get-top-token-holders) to get a list of top token holders, and then transferring their balances to `target`.
 
-Tokens for which `brownie-testing-tokens` currently implements custom minting logic are:
+Tokens for which custom logic is currently implemented:
 
 - [x] Aave tokens
 - [x] LinkUSD

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -39,11 +39,11 @@ class MintableForkToken(Contract):
         # check for token name if no custom minting
         # logic exists for address
         for name in _token_names:
-            if self.name().startswith(name):
+            if hasattr(self, 'name') and self.name().startswith(name):
                 fn_name = f"mint_{name}"
                 if hasattr(sys.modules[__name__], fn_name):
                     getattr(sys.modules[__name__], fn_name)(
-                        self, self.UNDERLYING_ASSET_ADDRESS(), amount)
+                        MintableForkToken(self.UNDERLYING_ASSET_ADDRESS()), target, amount)
                     return
 
         # if no custom logic, fetch a list of the top

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -6,6 +6,8 @@ from typing import Dict, List
 
 _token_holders: Dict = {}
 
+_token_names = ["Aave"]
+
 
 def get_top_holders(address: str) -> List:
     address = to_address(address)
@@ -33,6 +35,16 @@ class MintableForkToken(Contract):
         if hasattr(sys.modules[__name__], fn_name):
             getattr(sys.modules[__name__], fn_name)(self, target, amount)
             return
+
+        # check for token name if no custom minting
+        # logic exists for address
+        for name in _token_names:
+            if self.name().startswith(name):
+                fn_name = f"mint_{name}"
+                if hasattr(sys.modules[__name__], fn_name):
+                    getattr(sys.modules[__name__], fn_name)(
+                        self, self.UNDERLYING_ASSET_ADDRESS(), amount)
+                    return
 
         # if no custom logic, fetch a list of the top
         # token holders and start stealing from them
@@ -74,3 +86,34 @@ def mint_0x674C6Ad92Fd080e4004b2312b45f796a192D27a0(
 ) -> None:
     # USDN
     token.deposit(target, amount, {"from": "0x90f85042533F11b362769ea9beE20334584Dcd7D"})
+
+
+def mint_0x5228a22e72ccC52d415EcFd199F99D0665E7733b(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # pBTC
+    token.mint(target, amount, {'from': "0x3423Fb35149875e965f06c926DA8BA82D63f7ddb"})
+
+
+def mint_0x4A64515E5E1d1073e83f30cB97BEd20400b66E10(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # wZEC
+    token.mint(target, amount, {"from": "0x5Ca1262e25A5Fb6CA8d74850Da2753f0c896e16c"})
+
+
+def mint_0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # renZEC
+    token.mint(target, amount, {"from": "0xc3BbD5aDb611dd74eCa6123F05B18acc886e122D"})
+
+
+def mint_Aave(token: MintableForkToken, target: str, amount: int) -> None:
+    # aave token
+    lending_pool = Contract(
+        "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
+    token._mint_for_testing(target, amount)
+    token.approve(lending_pool, amount, {'from': target})
+    lending_pool.deposit(token, amount,
+                         target, 0, {'from': target})

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -109,6 +109,18 @@ def mint_0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2(
     token.mint(target, amount, {"from": "0xc3BbD5aDb611dd74eCa6123F05B18acc886e122D"})
 
 
+def mint_0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D(token: MintableForkToken, target: str, amount: int) -> None:
+    # renBTC
+    token.mint(target, amount, {
+        "from": "0xe4b679400F0f267212D5D812B95f58C83243EE71"})
+
+
+def mint_0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599(token: MintableForkToken, target: str, amount: int) -> None:
+    # wBTC
+    token.mint(target, amount, {"from": "0xCA06411bd7a7296d7dbdd0050DFc846E95fEBEB7"})
+    return
+
+
 def mint_Aave(token: MintableForkToken, target: str, amount: int) -> None:
     # aave token
     lending_pool = Contract(

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -42,8 +42,7 @@ class MintableForkToken(Contract):
             if hasattr(self, 'name') and self.name().startswith(name):
                 fn_name = f"mint_{name}"
                 if hasattr(sys.modules[__name__], fn_name):
-                    getattr(sys.modules[__name__], fn_name)(
-                        MintableForkToken(self.UNDERLYING_ASSET_ADDRESS()), target, amount)
+                    getattr(sys.modules[__name__], fn_name)(self, target, amount)
                     return
 
         # if no custom logic, fetch a list of the top
@@ -140,6 +139,7 @@ def mint_0x4A64515E5E1d1073e83f30cB97BEd20400b66E10(
 
 def mint_Aave(token: MintableForkToken, target: str, amount: int) -> None:
     # aave token
+    token = MintableForkToken(token.UNDERLYING_ASSET_ADDRESS())
     lending_pool = Contract(
         "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
     token._mint_for_testing(target, amount)

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -73,21 +73,6 @@ def mint_0x0E2EC54fC0B509F445631Bf4b91AB8168230C752(
     token.mint(target, amount, {"from": "0x62F31E08e279f3091d9755a09914DF97554eAe0b"})
 
 
-def mint_0x196f4727526eA7FB1e17b2071B3d8eAA38486988(
-    token: MintableForkToken, target: str, amount: int
-) -> None:
-    # RSV
-    token.changeMaxSupply(2 ** 128, {"from": token.owner()})
-    token.mint(target, amount, {"from": token.minter()})
-
-
-def mint_0x674C6Ad92Fd080e4004b2312b45f796a192D27a0(
-    token: MintableForkToken, target: str, amount: int
-) -> None:
-    # USDN
-    token.deposit(target, amount, {"from": "0x90f85042533F11b362769ea9beE20334584Dcd7D"})
-
-
 def mint_0x5228a22e72ccC52d415EcFd199F99D0665E7733b(
     token: MintableForkToken, target: str, amount: int
 ) -> None:
@@ -95,11 +80,10 @@ def mint_0x5228a22e72ccC52d415EcFd199F99D0665E7733b(
     token.mint(target, amount, {'from': "0x3423Fb35149875e965f06c926DA8BA82D63f7ddb"})
 
 
-def mint_0x4A64515E5E1d1073e83f30cB97BEd20400b66E10(
-    token: MintableForkToken, target: str, amount: int
-) -> None:
-    # wZEC
-    token.mint(target, amount, {"from": "0x5Ca1262e25A5Fb6CA8d74850Da2753f0c896e16c"})
+def mint_0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D(token: MintableForkToken, target: str, amount: int) -> None:
+    # renBTC
+    token.mint(target, amount, {
+        "from": "0xe4b679400F0f267212D5D812B95f58C83243EE71"})
 
 
 def mint_0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2(
@@ -109,16 +93,49 @@ def mint_0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2(
     token.mint(target, amount, {"from": "0xc3BbD5aDb611dd74eCa6123F05B18acc886e122D"})
 
 
-def mint_0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D(token: MintableForkToken, target: str, amount: int) -> None:
-    # renBTC
+def mint_0x196f4727526eA7FB1e17b2071B3d8eAA38486988(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # RSV
+    token.changeMaxSupply(2 ** 128, {"from": token.owner()})
+    token.mint(target, amount, {"from": token.minter()})
+
+
+def mint_0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6(token: MintableForkToken, target: str, amount: int) -> None:
+    # Synth sBTC
+    target_contract = Contract(
+        "0xDB91E4B3b6E19bF22E810C43273eae48C9037e74")
+    target_contract.issue(target, amount, {
+        "from": "0x778D2d3E3515e42573EB1e6a8d8915D4a22D9d54"})
+
+
+def mint_0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa(token: MintableForkToken, target: str, amount: int) -> None:
+    # tBTC
     token.mint(target, amount, {
-        "from": "0xe4b679400F0f267212D5D812B95f58C83243EE71"})
+        "from": "0x526c08E5532A9308b3fb33b7968eF78a5005d2AC"})
+
+
+def mint_0x674C6Ad92Fd080e4004b2312b45f796a192D27a0(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # USDN
+    token.deposit(target, amount, {"from": "0x90f85042533F11b362769ea9beE20334584Dcd7D"})
 
 
 def mint_0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599(token: MintableForkToken, target: str, amount: int) -> None:
     # wBTC
     token.mint(target, amount, {"from": "0xCA06411bd7a7296d7dbdd0050DFc846E95fEBEB7"})
     return
+
+
+def mint_0x4A64515E5E1d1073e83f30cB97BEd20400b66E10(
+    token: MintableForkToken, target: str, amount: int
+) -> None:
+    # wZEC
+    token.mint(target, amount, {"from": "0x5Ca1262e25A5Fb6CA8d74850Da2753f0c896e16c"})
+
+
+# to add custom minting logic for a token that starts with [NAME], add [NAME] to `_token_names` and add a function `mint_[NAME]`
 
 
 def mint_Aave(token: MintableForkToken, target: str, amount: int) -> None:


### PR DESCRIPTION
### What I did

* Added custom minting logic for tokens: pBTC, wZEC, renZEC, renBTC, wBTC, sBTC, tBTC, aave tokens
* Added handling of custom minting logic if token name starts with a specified prefix (e.g. 'AAVE') and custom minting logic for address does not exist


