### PR TITLE
feat: add skip_holders and ETHPLORER_API_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie-token-tester)
+### Changed
+- Added `skip_holders` feature to skip some holders in default minting process.
+- Added `$ETHPLORER_API_KEY` to use custom key.
 
 ## [0.2.2](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.2.2) - 2021-06-01
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This method increases the balance of `target` by `amount`. It may be called by a
 
 `MintableForkToken` is used to standardize the process of minting tokens when working in a [forked mainnet](https://eth-brownie.readthedocs.io/en/stable/network-management.html#using-a-forked-development-network) environment. The `MintableForkToken` class inherits from and may be used interchangeably with the [`Contract`](https://eth-brownie.readthedocs.io/en/stable/api-network.html#contract-and-projectcontract) class. It exposes one additional method, `_mint_for_testing`, with the same API as given above.
 
-For tokens where [custom logic is implemented](https://github.com/iamdefinitelyahuman/brownie-token-tester/blob/master/brownie_tokens/forked.py#L52), this is an actual minting event. For most tokens, the "minting" process involves a query to the [Ethplorer API](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#get-top-token-holders) to get a list of top token holders, and then transferring their balances to `target`.
+For tokens where [custom logic is implemented](https://github.com/iamdefinitelyahuman/brownie-token-tester/blob/master/brownie_tokens/forked.py#L52), this is an actual minting event. For most tokens, the "minting" process involves a query to the [Ethplorer API](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#get-top-token-holders) to get a list of top token holders, and then transferring their balances to `target`. If you want to exclude some holders from this process use `skip_holders(*addresses)`. If you have too many requests at a time set `$ETHPLORER_API_KEY`(see [ethplorer.io](https://ethplorer.io)) as environment variable.
 
 Tokens for which custom logic is currently implemented:
 

--- a/brownie_tokens/__init__.py
+++ b/brownie_tokens/__init__.py
@@ -1,6 +1,6 @@
 import brownie
 
-from brownie_tokens.forked import MintableForkToken
+from brownie_tokens.forked import BrownieTokensError, MintableForkToken, skip_holders
 from brownie_tokens.template import ERC20
 
 brownie.config["autofetch_sources"] = True

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -1,12 +1,29 @@
+import os
 import requests
 import sys
 from brownie import Contract, Wei
 from brownie.convert import to_address
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+_ethplorer_api_key: str = os.getenv("ETHPLORER_API_KEY") or "freekey"
 
 _token_holders: Dict = {}
+_skip_list: List[str] = []
 
 _token_names = ["Aave"]
+
+
+class BrownieTokensError(Exception):
+    pass
+
+
+def update_skipped_addresses(token: Optional[str] = None) -> None:
+    if token:
+        for address in _skip_list:
+            _token_holders[token].remove(address)
+    else:
+        for token in _token_holders:
+            update_skipped_addresses(token)
 
 
 def get_top_holders(address: str) -> List:
@@ -14,14 +31,36 @@ def get_top_holders(address: str) -> List:
     if address not in _token_holders:
         holders = requests.get(
             f"https://api.ethplorer.io/getTopTokenHolders/{address}",
-            params={"apiKey": "freekey", "limit": "50"},
+            params={"apiKey": _ethplorer_api_key, "limit": "50"},
         ).json()
+        if "error" in holders:
+            api_key_message = ""
+            if _ethplorer_api_key == "freekey":
+                api_key_message = (
+                    " Adding $ETHPLORER_API_KEY (from https://ethplorer.io) as environment variable"
+                    " may solve the problem."
+                )
+            raise BrownieTokensError(
+                f"Ethplorer returned error: {holders['error']}." + api_key_message
+            )
+
         _token_holders[address] = [to_address(i["address"]) for i in holders["holders"]]
         if address in _token_holders[address]:
             # don't steal from the treasury - that could cause wierdness
             _token_holders[address].remove(address)
+        update_skipped_addresses(address)
 
     return _token_holders[address]
+
+
+def skip_holders(*addresses: str) -> None:
+    """
+    Addresses that will remain untouched via '_mint_for_testing'.
+    Does not include minting with custom logic.
+    """
+    global _skip_list
+    _skip_list = list(set(_skip_list + list(addresses)))
+    update_skipped_addresses()
 
 
 class MintableForkToken(Contract):

--- a/tests/forked/test_default_mint_logic.py
+++ b/tests/forked/test_default_mint_logic.py
@@ -1,0 +1,28 @@
+from brownie import Wei
+
+from brownie_tokens import MintableForkToken, skip_holders
+from brownie_tokens.forked import _token_holders
+
+# Token with default '_mint_for_testing' logic
+token_address_default = "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39"  # HEX
+
+
+def test_skip_list(alice):
+    token = MintableForkToken(token_address_default)
+    # Fetch top holders
+    token._mint_for_testing(alice, Wei(0))
+
+    holders = [_token_holders[token.address][i] for i in [0, 1, 10]]
+    initial_balances = [token.balanceOf(holder) for holder in holders]
+
+    # Should remove addresses from current lists
+    skip_holders(*holders)
+    token._mint_for_testing(alice, 10 ** 6)
+    for holder, initial_balance in zip(holders, initial_balances):
+        assert token.balanceOf(holder) == initial_balance
+
+    # Should not include addresses that were set to skip before
+    _token_holders.clear()
+    token._mint_for_testing(alice, 10 ** 6)
+    for holder, initial_balance in zip(holders, initial_balances):
+        assert token.balanceOf(holder) == initial_balance

--- a/tests/forked/test_ethplorer_api.py
+++ b/tests/forked/test_ethplorer_api.py
@@ -1,0 +1,23 @@
+import pytest
+from test_default_mint_logic import token_address_default
+
+import brownie_tokens.forked
+from brownie_tokens import BrownieTokensError, MintableForkToken
+
+
+@pytest.fixture(scope="function")
+def invalid_ethplorer_key():
+    prev_key = brownie_tokens.forked._ethplorer_api_key
+    brownie_tokens.forked._ethplorer_api_key = "invalid_key"
+    yield
+    brownie_tokens.forked._ethplorer_api_key = prev_key
+
+
+def test_ethplorer_error(alice, invalid_ethplorer_key):
+    brownie_tokens.forked._token_holders.clear()
+    ethplorer_error = {"code": 1, "message": "Invalid API key"}
+
+    token = MintableForkToken(token_address_default)
+    with pytest.raises(BrownieTokensError, match=f"Ethplorer returned error: {ethplorer_error}.*"):
+        token._mint_for_testing(alice, 10 ** 6)
+        assert False, "Should fail with Ethplorer request error."


### PR DESCRIPTION
### What I did
Added features:  
1) skip some holders and  
2) setting custom ethplorer api key.

Related issue: None

### How I did it
1) Added method `skip_holders` which updates a `_skip_list` and removes addresses from `_holders`.  
2) Check if `$ETHPLORER_API_KEY` is set or use `freekey`

### How to verify it
Added tests:  
1) `test_skip_list` skips few addresses and checks that they remain untouched.  
2) `test_ethplorer_error` checks that `_mint_for_testing` fails on bad key with custom error.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation (README.md)
- [x] I have added an entry to the changelog
