### PR TITLE
fix: handle remove non-existent element error in skip_holders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie-token-tester)
+- `skip_holders` bug(removing non-existing address from a list)
 
 ## [0.3.0](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.3.0) - 2021-06-22
 ### Added

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -19,8 +19,7 @@ class BrownieTokensError(Exception):
 
 def update_skipped_addresses(token: Optional[str] = None) -> None:
     if token:
-        for address in _skip_list:
-            _token_holders[token].remove(address)
+        _token_holders[token] = [a for a in _token_holders[token] if a not in _skip_list]
     else:
         for token in _token_holders:
             update_skipped_addresses(token)

--- a/tests/forked/test_default_mint_logic.py
+++ b/tests/forked/test_default_mint_logic.py
@@ -1,4 +1,4 @@
-from brownie import Wei
+from brownie import ZERO_ADDRESS, Wei
 
 from brownie_tokens import MintableForkToken, skip_holders
 from brownie_tokens.forked import _token_holders
@@ -16,7 +16,8 @@ def test_skip_list(alice):
     initial_balances = [token.balanceOf(holder) for holder in holders]
 
     # Should remove addresses from current lists
-    skip_holders(*holders)
+    # ZERO_ADDRESS to check address that is not in _token_holders
+    skip_holders(*holders, ZERO_ADDRESS)
     token._mint_for_testing(alice, 10 ** 6)
     for holder, initial_balance in zip(holders, initial_balances):
         assert token.balanceOf(holder) == initial_balance

--- a/tests/forked/test_ethplorer_api.py
+++ b/tests/forked/test_ethplorer_api.py
@@ -18,6 +18,5 @@ def test_ethplorer_error(alice, invalid_ethplorer_key):
     ethplorer_error = {"code": 1, "message": "Invalid API key"}
 
     token = MintableForkToken(token_address_default)
-    with pytest.raises(BrownieTokensError, match=f"Ethplorer returned error: {ethplorer_error}.*"):
+    with pytest.raises(BrownieTokensError, match=f"Ethplorer returned error: {ethplorer_error}."):
         token._mint_for_testing(alice, 10 ** 6)
-        assert False, "Should fail with Ethplorer request error."


### PR DESCRIPTION
### What I did
Fixed bug with removing addresses from a list.

Related issue: None

### How to verify it
Added in `test_skip_list`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation (README.md)
- [x] I have added an entry to the changelog
