### PR TITLE
V0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie-token-tester)
 
+## [0.3.2](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.3.2) - 2021-07-06
+### Fixed
+- pull EURS minter via `eth_getStorageAt`
+- allow mixing returns `None` with revert
+
 ## [0.3.1](https://github.com/iamdefinitelyahuman/brownie-token-tester/tree/v0.3.1) - 2021-06-23
 ### Fixed
 - `skip_holders` bug (removing non-existing address from a list)

--- a/brownie_tokens/forked.py
+++ b/brownie_tokens/forked.py
@@ -1,7 +1,7 @@
 import os
 import requests
 import sys
-from brownie import Contract, Wei
+from brownie import Contract, Wei, web3
 from brownie.convert import to_address
 from typing import Dict, List, Optional
 
@@ -139,7 +139,7 @@ def mint_0xdB25f211AB05b1c97D595516F45794528a807ad8(
     token: MintableForkToken, target: str, amount: int
 ) -> None:
     # EURS
-    owner = "0x2EbBbc541E8f8F24386FA319c79CedA0579f1Efb"
+    owner = web3.eth.getStorageAt(token.address, 2)[-20:].hex()
     token.createTokens(amount, {"from": owner})
     token.transfer(target, amount, {"from": owner})
 

--- a/brownie_tokens/template.py
+++ b/brownie_tokens/template.py
@@ -76,7 +76,7 @@ def ERC20(
     if fail not in FAIL_STATEMENT:
         valid_keys = [str(i) for i in FAIL_STATEMENT.keys()]
         raise ValueError(f"Invalid value for `fail`, valid options are: {', '.join(valid_keys)}")
-    if None in (fail, success) and fail is not success:
+    if None in (fail, success) and fail is not success and fail != "revert":
         raise ValueError("Cannot use `None` for only one of `success` and `fail`.")
 
     source = TEMPLATE.format(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 
 [bumpversion:file:setup.py]
 
@@ -28,4 +28,3 @@ addopts =
 	--cov brownie_tokens/
 	--cov-report term
 	--cov-report xml
-

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="brownie-token-tester",
     packages=find_packages(exclude=["tests", "tests.*"]),
     py_modules=["brownie_tokens"],
-    version="0.3.1",  # don't change this manually, use bumpversion instead
+    version="0.3.2",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="Helper objects for generating ERC20s while testing a Brownie project.",
     long_description=long_description,


### PR DESCRIPTION
### What I did
- pull EURS minter via `eth_getStorageAt`
- allow mixing returns `None` with revert
- update changelog, bump version to `v0.3.2`